### PR TITLE
Empty fields fix

### DIFF
--- a/betterproto/__init__.py
+++ b/betterproto/__init__.py
@@ -644,8 +644,12 @@ class Message(ABC):
 
     @classmethod
     def _type_hint(cls, field_name: str) -> Type:
-        module = inspect.getmodule(cls)
-        type_hints = get_type_hints(cls, vars(module))
+        global_vars = {}
+        for base in inspect.getmro(cls):
+            module = inspect.getmodule(base)
+            global_vars.update(vars(module))
+
+        type_hints = get_type_hints(cls, global_vars)
         return type_hints[field_name]
 
     @classmethod

--- a/betterproto/__init__.py
+++ b/betterproto/__init__.py
@@ -611,8 +611,16 @@ class Message(ABC):
                     output += _serialize_single(meta.number, TYPE_BYTES, buf)
                 else:
                     for item in value:
-                        output += _serialize_single(
-                            meta.number, meta.proto_type, item, wraps=meta.wraps or ""
+                        output += (
+                            _serialize_single(
+                                meta.number,
+                                meta.proto_type,
+                                item,
+                                wraps=meta.wraps or "",
+                            )
+                            # if it's an empty message it still needs to be represented
+                            # as an item in the repeated list
+                            or b"\n\x00"
                         )
             elif isinstance(value, dict):
                 for k, v in value.items():

--- a/betterproto/__init__.py
+++ b/betterproto/__init__.py
@@ -843,9 +843,9 @@ class Message(ABC):
                         self._betterproto.cls_by_field[field_name]
                     )  # type: ignore
                     if isinstance(v, list):
-                        output[cased_name] = [enum_values[e].name for e in v]
+                        output[cased_name] = [enum_values[e].value for e in v]
                     else:
-                        output[cased_name] = enum_values[v].name
+                        output[cased_name] = enum_values[v].value
                 else:
                     output[cased_name] = v
         return output


### PR DESCRIPTION
Uses fix for serializing empty messages from https://github.com/danielgtaylor/python-betterproto/pull/180

Also fixes inheritance from betterproto messages (cover cases when it tries to resolve module by name in the module the class sits).

And serialize enum by value, instead of by name. This fixes cases for comparing
```python
'IOS' in [DeviceType.IOS, DeviceType.Android]  # False - serializing by name
0 in [DeviceType.IOS, DeviceType.Android]  # True- serializing by value
```